### PR TITLE
Create intermediate models

### DIFF
--- a/models/intermediate/int_addresses.sql
+++ b/models/intermediate/int_addresses.sql
@@ -1,0 +1,46 @@
+with addresses as (
+
+    select *
+    from {{ ref('stg_addresses') }}
+
+)
+
+, state_provinces as (
+
+    select *
+    from {{ ref('stg_state_provinces') }}
+
+)
+
+, country_regions as (
+
+    select *
+    from {{ ref('stg_country_regions') }}
+
+)
+
+, joins as (
+
+    select
+        -- primary key
+        addresses.address_id
+
+        -- foreign keys
+        , country_regions.country_region_code
+        , state_provinces.state_province_id
+
+        -- properties
+        , addresses.city_name
+        , country_regions.country_region_name
+        , state_provinces.state_province_name
+        
+    from addresses
+    left join state_provinces
+        on addresses.state_province_id = state_provinces.state_province_id
+    left join country_regions
+        on state_provinces.country_region_code = country_regions.country_region_code
+
+)
+
+select *
+from joins

--- a/models/intermediate/int_customers.sql
+++ b/models/intermediate/int_customers.sql
@@ -1,0 +1,53 @@
+with customers as (
+
+    select *
+    from {{ ref('stg_customers') }}
+
+)
+
+, people as (
+
+    select *
+    from {{ ref('stg_people') }}
+
+)
+
+, stores as (
+
+    select *
+    from {{ ref('stg_stores') }}
+
+)
+
+, joins as (
+
+    select
+        -- primary key
+        customers.customer_id
+
+        -- foreign keys
+        , people.person_id
+        , stores.store_id
+
+        -- properties
+        , case
+            when people.person_type_id = 'SC' then 'Store Contact'
+            when people.person_type_id = 'IN' then 'Individual Customer'
+            when people.person_type_id = 'SP' then 'Sales Person'
+            when people.person_type_id = 'EM' then 'Employee'
+            when people.person_type_id = 'VC' then 'Vendor Contact'
+            when people.person_type_id = 'GC' then 'General Contact'
+        end as person_type
+        , coalesce(people.full_name, 'unregistered customer') as full_name
+        , stores.store_name
+
+    from customers
+    left join people
+        on customers.person_id = people.person_id
+    left join stores
+        on customers.store_id = stores.store_id
+
+)
+
+select *
+from joins

--- a/models/intermediate/int_dates.sql
+++ b/models/intermediate/int_dates.sql
@@ -1,0 +1,37 @@
+with dates as (
+
+    select *
+    from {{ ref('stg_dates') }}
+
+)
+
+, transform as (
+
+    select
+        -- primary key
+        order_date
+
+        -- properties
+        , extract(year from order_date) as order_year
+        , case
+            when extract(month from order_date) = 1 then 'jan'
+            when extract(month from order_date) = 2 then 'feb'
+            when extract(month from order_date) = 3 then 'mar'
+            when extract(month from order_date) = 4 then 'apr'
+            when extract(month from order_date) = 5 then 'may'
+            when extract(month from order_date) = 6 then 'jun'
+            when extract(month from order_date) = 7 then 'jul'
+            when extract(month from order_date) = 8 then 'aug'
+            when extract(month from order_date) = 9 then 'sep'
+            when extract(month from order_date) = 10 then 'oct'
+            when extract(month from order_date) = 11 then 'nov'
+            when extract(month from order_date) = 12 then 'dec'
+        end as order_month
+        , extract(day from order_date) as order_day
+
+    from dates
+
+)
+
+select *
+from transform

--- a/models/intermediate/int_orders.sql
+++ b/models/intermediate/int_orders.sql
@@ -1,0 +1,49 @@
+with sales_order_headers as (
+
+    select *
+    from {{ ref('stg_sales_order_headers') }}
+
+)
+
+, sales_order_details as (
+
+    select *
+    from {{ ref('stg_sales_order_details') }}
+
+)
+
+, joins as (
+
+    select
+        -- primary key
+        sales_order_headers.sales_order_id
+
+        -- foreign keys
+        , sales_order_details.sales_order_detail_id
+        , sales_order_details.product_id
+        , sales_order_headers.customer_id
+        , sales_order_headers.credit_card_id
+        , sales_order_headers.ship_to_address_id
+        , sales_order_headers.status_id
+
+        -- timestamps
+        , sales_order_headers.order_date
+
+        -- costs and quantities
+        , sales_order_details.order_quantity
+        , sales_order_details.unit_price
+        , sales_order_details.unit_price_discount
+        , sales_order_headers.order_subtotal
+
+         -- metrics
+        , sales_order_details.unit_price * sales_order_details.order_quantity as gross_sales
+        , sales_order_details.unit_price * sales_order_details.order_quantity - (1 - sales_order_details.unit_price_discount) as net_sales
+
+    from sales_order_headers
+    inner join sales_order_details
+        on sales_order_headers.sales_order_id = sales_order_details.sales_order_id
+
+)
+
+select *
+from joins

--- a/models/intermediate/int_products.sql
+++ b/models/intermediate/int_products.sql
@@ -1,0 +1,46 @@
+with products as (
+
+    select *
+    from {{ ref('stg_products') }}
+
+)
+
+, product_categories as (
+
+    select *
+    from {{ ref('stg_product_categories') }}
+
+)
+
+, product_subcategories as (
+
+    select *
+    from {{ ref('stg_product_subcategories') }}
+
+)
+
+, joins as (
+
+    select
+        -- primary keys
+        products.product_id
+
+        -- foreign keys
+        , product_categories.product_category_id
+        , product_subcategories.product_subcategory_id
+
+        -- properties
+        , products.product_name
+        , product_categories.product_category_name
+        , product_subcategories.product_subcategory_name
+
+    from products
+    left join product_subcategories
+        on products.product_subcategory_id = product_subcategories.product_subcategory_id
+    left join product_categories
+        on product_subcategories.product_category_id = product_categories.product_category_id
+
+)
+
+select *
+from joins

--- a/models/intermediate/int_sales_reasons.sql
+++ b/models/intermediate/int_sales_reasons.sql
@@ -1,0 +1,34 @@
+with sales_order_header_sales_reasons as (
+
+    select *
+    from {{ ref('stg_sales_order_header_sales_reasons') }}
+
+)
+
+, sales_reasons as (
+
+    select *
+    from {{ ref('stg_sales_reasons')}}
+
+)
+
+, joins as (
+
+    select
+        -- primary keys
+        sales_order_header_sales_reasons.sales_order_id
+
+        -- foreign keys
+        , sales_reasons.sales_reason_id
+
+        -- properties
+        , coalesce(sales_reasons.sales_reason, 'Unknown reason') as sales_reason
+
+    from sales_order_header_sales_reasons
+    left join sales_reasons
+        on sales_order_header_sales_reasons.sales_reason_id = sales_reasons.sales_reason_id
+
+)
+
+select *
+from joins

--- a/models/intermediate/int_status.sql
+++ b/models/intermediate/int_status.sql
@@ -1,0 +1,30 @@
+with status as (
+
+    select *
+    from {{ ref('stg_status') }}
+
+)
+
+, transformation as (
+
+    select
+        -- primary key
+        status_id
+
+        -- properties
+        , case
+            when status_id = 1 then 'in_process'
+            when status_id = 2 then 'approved'
+            when status_id = 3 then 'backordered'
+            when status_id = 4 then 'rejected'
+            when status_id = 5 then 'shipped'
+            when status_id = 6 then 'cancelled'
+            else 'no_status'
+        end as order_status
+
+    from status
+
+)
+
+select *
+from transformation


### PR DESCRIPTION
**Overview**

This pull request focuses on the implementation of intermediate models, which play a crucial role in the data transformation process. These models aim to prepare the staged data for further analysis and processing, enabling a streamlined workflow.

**Key changes**

- Implemented int_addresses intermediate model that combines address data from stg_addresses, stg_state_provinces, and stg_country_regions to create an unique address dataset.
- Created int_customers intermediate model that merges customer data from stg_customers with person details from stg_people and customer store data from stg_stores. This results in a unified customer dataset.
- Introduced int_dates intermediate model to handle date-related data transformations.
- Developed int_orders intermediate model, consolidating order data from stg_sales_order_headers and stg_sales_order_details to create the order dataset.
- Implemented int_products intermediate model, which combines product data from stg_products, stg_product_categories, and stg_product_subcategories to provide a product dataset.
- Created int_sales_reasons intermediate model by integrating data from stg_sales_order_header_sales_reasons and stg_sales_reasons, facilitating analysis based on sales reasons.
- Introduced int_status intermediate model to handle status-related data transformations.